### PR TITLE
feat: arXivジャーナルの正規化機能を追加

### DIFF
--- a/bibtex/middleware/formatter.py
+++ b/bibtex/middleware/formatter.py
@@ -57,7 +57,14 @@ class BibTeXFormatterMiddleware(BlockMiddleware):
 
     def _is_arxiv(self, entry: Entry) -> bool:
         """arXiv論文かどうか判定"""
-        return (prefix := entry.fields_dict.get("archiveprefix")) and prefix.value == "arXiv"
+        if (prefix := entry.fields_dict.get("archiveprefix")) and prefix.value == "arXiv":
+            return True
+
+        journal_field = entry.fields_dict.get("journal")
+        if not journal_field:
+            return False
+
+        return self._extract_arxiv_identifier_from_journal(journal_field.value) is not None
     
 
     def _create_arxiv_journal(self, entry: Entry) -> Entry:
@@ -67,7 +74,25 @@ class BibTeXFormatterMiddleware(BlockMiddleware):
             journal_value = f"arXiv:{eprint_value}"
             # journalフィールドを追加
             entry.fields.append(Field(key="journal", value=journal_value))
+            return entry
+
+        if "journal" in entry.fields_dict:
+            arxiv_id = self._extract_arxiv_identifier_from_journal(entry.fields_dict["journal"].value)
+            if arxiv_id:
+                normalized_value = f"arXiv:{arxiv_id}"
+                for field in entry.fields:
+                    if field.key.lower() == "journal":
+                        field.value = normalized_value
+                        break
         return entry
+
+
+    def _extract_arxiv_identifier_from_journal(self, journal_value: str) -> str | None:
+        """journal文字列からarXiv IDを抽出する。"""
+        match = re.search(r"arxiv\s*(?::|preprint\s+arxiv:)\s*([A-Za-z0-9./-]+)", journal_value, flags=re.IGNORECASE)
+        if not match:
+            return None
+        return match.group(1)
     
 
     def _create_url_from_doi(self, entry: Entry) -> Entry:

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -368,3 +368,26 @@ def test_brace_colon():
 """
     simplified_bib = simplify_bibtex_entry(raw_bib, abbreviation_mode="both")
     assert simplified_bib == expected_simplified_bib
+
+
+def test_simplify_arxiv_preprint_journal_entry():
+    """journal に arXiv preprint 形式が入った article を正規化できることを確認する。"""
+    raw_bib = """@article{fizz,
+  title={Hello World},
+  author={Fizz Buzz},
+  journal={arXiv preprint arXiv:0000.00000},
+  year={2026},
+  url = "https://arxiv.org/abs/0000.00000"
+}"""
+
+    expected_simplified_bib = """@article{fizz,
+    title = {{Hello World}},
+    author = "Fizz Buzz",
+    journal = "arXiv:0000.00000",
+    year = "2026",
+    url = "https://arxiv.org/abs/0000.00000",
+}
+"""
+
+    simplified_bib = simplify_bibtex_entry(raw_bib, abbreviation_mode="both")
+    assert simplified_bib == expected_simplified_bib


### PR DESCRIPTION
- BibTeXFormatterMiddlewareにおいて、_is_arxivメソッドを修正し、journalフィールドからarXiv IDを抽出できるようにしました。
- _create_arxiv_journalメソッドを修正し、journalフィールドが存在する場合にarXiv IDを正規化する処理を追加しました。
- test_simplify.pyにarXiv preprint形式のjournalを正規化するテストを追加しました。